### PR TITLE
Added missing backslash when Exception is thrown in Controller

### DIFF
--- a/src/Cajogos/Biscuit/Controller.php
+++ b/src/Cajogos/Biscuit/Controller.php
@@ -11,6 +11,6 @@ abstract class Controller
 
 	public static function display()
 	{
-		throw new Exception('No display function has been called from ' . get_class(static::get()));
+		throw new \Exception('No display function has been called from ' . get_class(static::get()));
 	}
 }


### PR DESCRIPTION
With missing backslash, the page fails when no display function is present.